### PR TITLE
added continue to next breakpoint; prevented starting debugging without breakpoints; ui layout tweaks

### DIFF
--- a/pdb_new_ui_in_development/codeeditor.cpp
+++ b/pdb_new_ui_in_development/codeeditor.cpp
@@ -128,6 +128,8 @@ void CodeEditor::loadSample(const QString &text)
     execLine = -1;
     breakpoints.clear();
     lineNumberArea->update();
+    emit debugStateChanged(false); // notify buttons
+    emit breakpointsChanged(0);    // reset (just in case)
 }
 
 void CodeEditor::startDebug()
@@ -146,6 +148,7 @@ void CodeEditor::startDebug()
         if (first < 0)
             return; // Just in case.
         execLine = qBound(0, first, blockCount() - 1);
+        emit debugStateChanged(true); // debug session started
     } else {
         // Continue: Move to the next breakpoint below the current line.
         int nextStop = -1;
@@ -181,6 +184,7 @@ void CodeEditor::stopDebug()
         execLine = -1;                 // Arrow is hidden.
         lineNumberArea->update();      // Redraw gutter.
         update();                      // Redraw viewport.
+        emit debugStateChanged(false);
     }
 }
 
@@ -208,6 +212,7 @@ void CodeEditor::toggleBreakpointAtGutterY(int localY)
                 breakpoints.remove(ln);
             else
                 breakpoints.insert(ln);
+            emit breakpointsChanged(breakpoints.size());
             break;
         }
         block = block.next();

--- a/pdb_new_ui_in_development/codeeditor.h
+++ b/pdb_new_ui_in_development/codeeditor.h
@@ -19,6 +19,10 @@ public:
     QSet<int> breakpoints; // 0-based
     int execLine = -1;     // -1 = not running
 
+signals:
+    void debugStateChanged(bool running); // True at the start of a "session", false when stopped
+    void breakpointsChanged(int count);   // Whenever a set of breakpoints changes
+
 public slots:
     void loadSample(const QString &text);
     void startDebug();

--- a/pdb_new_ui_in_development/main.cpp
+++ b/pdb_new_ui_in_development/main.cpp
@@ -34,6 +34,29 @@ int main(int argc, char** argv) {
     QObject::connect(stepBtn,  &QPushButton::clicked, editor, &CodeEditor::step);
     QObject::connect(stopBtn,  &QPushButton::clicked, editor, &CodeEditor::stopDebug);
 
+    bool running = false;
+    int bpCount  = 0;
+
+    auto updateStartText = [&](){
+      startBtn->setText( (running && bpCount > 1) ? "Continue" : "Start Debugging" );
+    };
+
+    QObject::connect(editor, &CodeEditor::debugStateChanged,
+                     [&](bool isRunning){ running = isRunning; updateStartText(); });
+    QObject::connect(editor, &CodeEditor::breakpointsChanged,
+                     [&](int count){ bpCount = count; updateStartText(); });
+
+    // TODO: find a better way to do that.
+    // ------------------------------------------------------------
+    stepBtn->setEnabled(false);
+    stopBtn->setEnabled(false);
+    QObject::connect(editor, &CodeEditor::debugStateChanged,
+        [&](bool isRunning) {
+            stepBtn->setEnabled(isRunning);
+            stopBtn->setEnabled(isRunning);
+    });
+    // ------------------------------------------------------------
+
     QWidget window;
     auto* layout = new QVBoxLayout(&window);
     layout->addWidget(editor, 1);


### PR DESCRIPTION
Implemented 'Continue' to jump to the next breakpoint, blocked starting the debugger when no breakpoints exist, and repositioned several GUI elements.